### PR TITLE
feat: Change an SNS ledger's token-name and token-symbol through the ManageLedgerParameters proposal type.

### DIFF
--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -1424,6 +1424,16 @@ pub fn icrc1_transfer(
     }
 }
 
+pub fn icrc1_name(machine: &StateMachine, ledger_id: CanisterId) -> String {
+    let result = query(machine, ledger_id, "icrc1_name", Encode!().unwrap()).unwrap();
+    Decode!(&result, String).unwrap()
+}
+
+pub fn icrc1_symbol(machine: &StateMachine, ledger_id: CanisterId) -> String {
+    let result = query(machine, ledger_id, "icrc1_symbol", Encode!().unwrap()).unwrap();
+    Decode!(&result, String).unwrap()
+}
+
 /// Claim a staked neuron for an SNS StateMachine test
 // Note: Should be moved to sns/test_helpers/state_test_helpers.rs when dependency graph is cleaned up
 pub fn sns_claim_staked_neuron(

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -243,7 +243,11 @@ type ManageDappCanisterSettings = record {
   memory_allocation : opt nat64;
   compute_allocation : opt nat64;
 };
-type ManageLedgerParameters = record { transfer_fee : opt nat64 };
+type ManageLedgerParameters = record {
+  token_symbol : opt text;
+  transfer_fee : opt nat64;
+  token_name : opt text;
+};
 type ManageNeuron = record { subaccount : vec nat8; command : opt Command };
 type ManageNeuronResponse = record { command : opt Command_1 };
 type ManageSnsMetadata = record {

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -245,7 +245,11 @@ type ManageDappCanisterSettings = record {
   memory_allocation : opt nat64;
   compute_allocation : opt nat64;
 };
-type ManageLedgerParameters = record { transfer_fee : opt nat64 };
+type ManageLedgerParameters = record {
+  token_symbol : opt text;
+  transfer_fee : opt nat64;
+  token_name : opt text;
+};
 type ManageNeuron = record { subaccount : vec nat8; command : opt Command };
 type ManageNeuronResponse = record { command : opt Command_1 };
 type ManageSnsMetadata = record {

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -350,6 +350,8 @@ message TransferSnsTreasuryFunds {
 // Fields with None values will remain unchanged.
 message ManageLedgerParameters {
   optional uint64 transfer_fee = 1;
+  optional string token_name = 2;
+  optional string token_symbol = 3;
 }
 
 // A proposal to mint SNS tokens to (optionally a Subaccount of) the

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -404,6 +404,10 @@ pub mod transfer_sns_treasury_funds {
 pub struct ManageLedgerParameters {
     #[prost(uint64, optional, tag = "1")]
     pub transfer_fee: ::core::option::Option<u64>,
+    #[prost(string, optional, tag = "2")]
+    pub token_name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "3")]
+    pub token_symbol: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// A proposal to mint SNS tokens to (optionally a Subaccount of) the
 /// target principal.

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -2716,6 +2716,8 @@ impl Governance {
         let ledger_upgrade_arg =
             candid::encode_one(Some(LedgerArgument::Upgrade(Some(UpgradeArgs {
                 transfer_fee: manage_ledger_parameters.transfer_fee.map(|tf| tf.into()),
+                token_name: manage_ledger_parameters.token_name,
+                token_symbol: manage_ledger_parameters.token_symbol,
                 ..UpgradeArgs::default()
             }))))
             .unwrap();

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -1270,6 +1270,14 @@ fn validate_and_render_manage_ledger_parameters(
         );
         no_change = false;
     }
+    if let Some(token_name) = &manage_ledger_parameters.token_name {
+        render += &format!("# Set new token name: {}. \n", token_name);
+        no_change = false;
+    }
+    if let Some(token_symbol) = &manage_ledger_parameters.token_symbol {
+        render += &format!("# Set new token symbol: {}. \n", token_symbol);
+        no_change = false;
+    }
     if no_change {
         Err(String::from(
             "ManageLedgerParameters must change at least one value, all values are None",
@@ -3835,13 +3843,17 @@ Version {
     #[test]
     fn test_validate_and_render_manage_ledger_parameters() {
         let new_fee = 751;
+        let new_token_name = "Random Token".to_string();
+        let new_token_symbol = "RTK".to_string();
         let render = validate_and_render_manage_ledger_parameters(&ManageLedgerParameters {
             transfer_fee: Some(new_fee),
+            token_name: Some(new_token_name.clone()),
+            token_symbol: Some(new_token_symbol.clone()),
         })
         .unwrap();
         assert_eq!(
             render,
-            format!("# Proposal to change ledger parameters:\n# Set token transfer fee: {} token-quantums. \n", new_fee)
+            format!("# Proposal to change ledger parameters:\n# Set token transfer fee: {} token-quantums. \n# Set new token name: {}. \n# Set new token symbol: {}. \n", new_fee, new_token_name, new_token_symbol)
         );
     }
 

--- a/rs/sns/test_utils/src/itest_helpers.rs
+++ b/rs/sns/test_utils/src/itest_helpers.rs
@@ -199,6 +199,16 @@ impl SnsTestsInitPayloadBuilder {
         self
     }
 
+    pub fn with_ledger_token_name(&mut self, token_name: String) -> &mut Self {
+        self.ledger.token_name = token_name;
+        self
+    }
+
+    pub fn with_ledger_token_symbol(&mut self, token_symbol: String) -> &mut Self {
+        self.ledger.token_symbol = token_symbol;
+        self
+    }
+
     pub fn with_governance_init_payload(
         &mut self,
         governance_init_payload_builder: GovernanceCanisterInitPayloadBuilder,


### PR DESCRIPTION
This feature makes it possible for an SNS to change it's ledger's token-name and token-symbol through the ManageLedgerParameters SNS proposal type.