### PR TITLE
SNS governance canister, show each neuron reward portion of the reward events.

### DIFF
--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -316,6 +316,7 @@ type Neuron = record {
   auto_stake_maturity : opt bool;
   aging_since_timestamp_seconds : nat64;
   dissolve_state : opt DissolveState;
+  reward_events_to_neuron_reward_e8s : vec record { nat64; nat64 };
   voting_power_percentage_multiplier : nat64;
   vesting_period_seconds : opt nat64;
   disburse_maturity_in_progress : vec DisburseMaturityInProgress;

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -315,8 +315,11 @@ type Neuron = record {
   source_nns_neuron_id : opt nat64;
   auto_stake_maturity : opt bool;
   aging_since_timestamp_seconds : nat64;
+  reward_event_end_timestamp_seconds_to_neuron_reward_e8s : vec record {
+    nat64;
+    nat64;
+  };
   dissolve_state : opt DissolveState;
-  reward_events_to_neuron_reward_e8s : vec record { nat64; nat64 };
   voting_power_percentage_multiplier : nat64;
   vesting_period_seconds : opt nat64;
   disburse_maturity_in_progress : vec DisburseMaturityInProgress;

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -322,6 +322,7 @@ type Neuron = record {
   auto_stake_maturity : opt bool;
   aging_since_timestamp_seconds : nat64;
   dissolve_state : opt DissolveState;
+  reward_events_to_neuron_reward_e8s : vec record { nat64; nat64 };
   voting_power_percentage_multiplier : nat64;
   vesting_period_seconds : opt nat64;
   disburse_maturity_in_progress : vec DisburseMaturityInProgress;

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -321,8 +321,11 @@ type Neuron = record {
   source_nns_neuron_id : opt nat64;
   auto_stake_maturity : opt bool;
   aging_since_timestamp_seconds : nat64;
+  reward_event_end_timestamp_seconds_to_neuron_reward_e8s : vec record {
+    nat64;
+    nat64;
+  };
   dissolve_state : opt DissolveState;
-  reward_events_to_neuron_reward_e8s : vec record { nat64; nat64 };
   voting_power_percentage_multiplier : nat64;
   vesting_period_seconds : opt nat64;
   disburse_maturity_in_progress : vec DisburseMaturityInProgress;

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -211,6 +211,16 @@ message Neuron {
   // with the oldest entries first, i.e. it holds for all i that:
   // entry[i].timestamp_of_disbursement_seconds <= entry[i+1].timestamp_of_disbursement_seconds
   repeated DisburseMaturityInProgress disburse_maturity_in_progress = 18;
+
+  message NeuronRewardPortion {
+    // the sum of the neuron_reward_e8s for all neurons in this reward event. 
+    uint64 reward_event_total_distributed_e8s_equivalent = 1;
+    // this specific neuron's neuron_reward_e8s
+    uint64 neuron_reward_e8s = 2;
+  }
+  // The keys are the reward-event-timestamps (end_timestamp_seconds) and the values are the distributed_e8s_equivalent and this specific neuron_reward_e8s for this reward-event.   
+  map<uint64, NeuronRewardPortion> reward_events_to_neuron_reward_portion = 19;
+
 }
 
 // The types of votes a neuron can issue.

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -212,14 +212,9 @@ message Neuron {
   // entry[i].timestamp_of_disbursement_seconds <= entry[i+1].timestamp_of_disbursement_seconds
   repeated DisburseMaturityInProgress disburse_maturity_in_progress = 18;
 
-  message NeuronRewardPortion {
-    // the sum of the neuron_reward_e8s for all neurons in this reward event. 
-    uint64 reward_event_total_distributed_e8s_equivalent = 1;
-    // this specific neuron's neuron_reward_e8s
-    uint64 neuron_reward_e8s = 2;
-  }
-  // The keys are the reward-event-timestamps (end_timestamp_seconds) and the values are the distributed_e8s_equivalent and this specific neuron_reward_e8s for this reward-event.   
-  map<uint64, NeuronRewardPortion> reward_events_to_neuron_reward_portion = 19;
+  // The keys are the reward-event-timestamps (end_timestamp_seconds) and the values are the neuron_reward_e8s for this reward-event.   
+  // Stores minimum 10 latest reward events. 
+  map<uint64, uint64> reward_events_to_neuron_reward_e8s = 19;
 
 }
 

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -213,7 +213,7 @@ message Neuron {
   repeated DisburseMaturityInProgress disburse_maturity_in_progress = 18;
 
   // The keys are the reward-event-timestamps (end_timestamp_seconds) and the values are the neuron_reward_e8s for this reward-event.   
-  // Stores minimum 10 latest reward events. 
+  // Stores minimum 5 latest reward events.
   map<uint64, uint64> reward_events_to_neuron_reward_e8s = 19;
 
 }

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -213,8 +213,8 @@ message Neuron {
   repeated DisburseMaturityInProgress disburse_maturity_in_progress = 18;
 
   // The keys are the reward-event-timestamps (end_timestamp_seconds) and the values are the neuron_reward_e8s for this reward-event.   
-  // Stores minimum 5 latest reward events.
-  map<uint64, uint64> reward_events_to_neuron_reward_e8s = 19;
+  // Stores at most MAX_KEEP_REWARD_EVENTS_TO_NEURON_REWARD_E8S_PER_NEURON latest reward events.
+  map<uint64, uint64> reward_event_end_timestamp_seconds_to_neuron_reward_e8s = 19;
 
 }
 

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -138,6 +138,10 @@ pub struct Neuron {
     /// entry\[i\].timestamp_of_disbursement_seconds <= entry\[i+1\].timestamp_of_disbursement_seconds
     #[prost(message, repeated, tag = "18")]
     pub disburse_maturity_in_progress: ::prost::alloc::vec::Vec<DisburseMaturityInProgress>,
+    /// The keys are the reward-event-timestamps (end_timestamp_seconds) and the values are the neuron_reward_e8s for this reward-event.
+    /// Stores minimum 5 latest reward events.
+    #[prost(btree_map = "uint64, uint64", tag = "19")]
+    pub reward_events_to_neuron_reward_e8s: ::prost::alloc::collections::BTreeMap<u64, u64>,
     /// The neuron's dissolve state, specifying whether the neuron is dissolving,
     /// non-dissolving, or dissolved.
     ///

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -139,9 +139,10 @@ pub struct Neuron {
     #[prost(message, repeated, tag = "18")]
     pub disburse_maturity_in_progress: ::prost::alloc::vec::Vec<DisburseMaturityInProgress>,
     /// The keys are the reward-event-timestamps (end_timestamp_seconds) and the values are the neuron_reward_e8s for this reward-event.
-    /// Stores minimum 5 latest reward events.
+    /// Stores at most MAX_KEEP_REWARD_EVENTS_TO_NEURON_REWARD_E8S_PER_NEURON latest reward events.
     #[prost(btree_map = "uint64, uint64", tag = "19")]
-    pub reward_events_to_neuron_reward_e8s: ::prost::alloc::collections::BTreeMap<u64, u64>,
+    pub reward_event_end_timestamp_seconds_to_neuron_reward_e8s:
+        ::prost::alloc::collections::BTreeMap<u64, u64>,
     /// The neuron's dissolve state, specifying whether the neuron is dissolving,
     /// non-dissolving, or dissolved.
     ///

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -4943,7 +4943,9 @@ impl Governance {
                 // prune
                 while neuron.reward_events_to_neuron_reward_e8s.len() > 10 {
                     // prune earliest. 
-                    
+                    neuron.reward_events_to_neuron_reward_e8s.remove(
+                        neuron.reward_events_to_neuron_reward_e8s.keys().min().clone()
+                    );
                 }
                 distributed_e8s_equivalent += neuron_reward_e8s;
             }

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -4935,6 +4935,16 @@ impl Governance {
                 } else {
                     neuron.maturity_e8s_equivalent += neuron_reward_e8s;
                 }
+                // Add the neuron_reward_e8s to the reward_events_to_neuron_reward_e8s map on the neuron. 
+                neuron.reward_events_to_neuron_reward_e8s.insert( 
+                    reward_event_end_timestamp_seconds, 
+                    neuron_reward_e8s
+                );
+                // prune
+                while neuron.reward_events_to_neuron_reward_e8s.len() > 10 {
+                    // prune earliest. 
+                    
+                }
                 distributed_e8s_equivalent += neuron_reward_e8s;
             }
         }

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -11,7 +11,7 @@ use crate::{
     logs::{ERROR, INFO},
     neuron::{
         NeuronState, RemovePermissionsStatus, DEFAULT_VOTING_POWER_PERCENTAGE_MULTIPLIER,
-        MAX_LIST_NEURONS_RESULTS,
+        MAX_LIST_NEURONS_RESULTS, MAX_KEEP_REWARD_EVENTS_TO_NEURON_REWARD_E8S_PER_NEURON
     },
     pb::{
         sns_root_types::{

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -4941,7 +4941,7 @@ impl Governance {
                     neuron_reward_e8s
                 );
                 // prune
-                while neuron.reward_events_to_neuron_reward_e8s.len() > 10 {
+                while neuron.reward_events_to_neuron_reward_e8s.len() > MAX_KEEP_REWARD_EVENTS_TO_NEURON_REWARD_E8S_PER_NEURON {
                     // prune earliest. 
                     neuron.reward_events_to_neuron_reward_e8s.remove(
                         neuron.reward_events_to_neuron_reward_e8s.keys().min().clone()

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -1321,6 +1321,7 @@ impl Governance {
             auto_stake_maturity: parent_neuron.auto_stake_maturity,
             vesting_period_seconds: None,
             disburse_maturity_in_progress: vec![],
+            reward_events_to_neuron_reward_e8s: BTreeMap::new(),
         };
 
         // Add the child neuron's id to the set of neurons with ongoing operations.
@@ -3769,6 +3770,7 @@ impl Governance {
             auto_stake_maturity: None,
             vesting_period_seconds: None,
             disburse_maturity_in_progress: vec![],
+            reward_events_to_neuron_reward_e8s: BTreeMap::new(),
         };
 
         // This also verifies that there are not too many neurons already.
@@ -3921,6 +3923,7 @@ impl Governance {
                 auto_stake_maturity: neuron_parameter.construct_auto_staking_maturity(),
                 vesting_period_seconds: None,
                 disburse_maturity_in_progress: vec![],
+                reward_events_to_neuron_reward_e8s: BTreeMap::new(),
             };
 
             // Add the neuron to the various data structures and indexes to support neurons. This
@@ -4935,16 +4938,16 @@ impl Governance {
                 } else {
                     neuron.maturity_e8s_equivalent += neuron_reward_e8s;
                 }
-                // Add the neuron_reward_e8s to the reward_events_to_neuron_reward_e8s map on the neuron. 
+                // Insert the neuron_reward_e8s into the reward_events_to_neuron_reward_e8s map on the neuron. 
                 neuron.reward_events_to_neuron_reward_e8s.insert( 
                     reward_event_end_timestamp_seconds, 
                     neuron_reward_e8s
                 );
                 // prune
-                while neuron.reward_events_to_neuron_reward_e8s.len() > MAX_KEEP_REWARD_EVENTS_TO_NEURON_REWARD_E8S_PER_NEURON {
-                    // prune earliest. 
+                while neuron.reward_events_to_neuron_reward_e8s.len() > MAX_KEEP_REWARD_EVENTS_TO_NEURON_REWARD_E8S_PER_NEURON as usize {
+                    // prune earliest.
                     neuron.reward_events_to_neuron_reward_e8s.remove(
-                        neuron.reward_events_to_neuron_reward_e8s.keys().min().clone()
+                        &neuron.reward_events_to_neuron_reward_e8s.keys().min().unwrap().clone()
                     );
                 }
                 distributed_e8s_equivalent += neuron_reward_e8s;

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -1321,7 +1321,7 @@ impl Governance {
             auto_stake_maturity: parent_neuron.auto_stake_maturity,
             vesting_period_seconds: None,
             disburse_maturity_in_progress: vec![],
-            reward_events_to_neuron_reward_e8s: BTreeMap::new(),
+            reward_event_end_timestamp_seconds_to_neuron_reward_e8s: BTreeMap::new(),
         };
 
         // Add the child neuron's id to the set of neurons with ongoing operations.
@@ -3770,7 +3770,7 @@ impl Governance {
             auto_stake_maturity: None,
             vesting_period_seconds: None,
             disburse_maturity_in_progress: vec![],
-            reward_events_to_neuron_reward_e8s: BTreeMap::new(),
+            reward_event_end_timestamp_seconds_to_neuron_reward_e8s: BTreeMap::new(),
         };
 
         // This also verifies that there are not too many neurons already.
@@ -3923,7 +3923,7 @@ impl Governance {
                 auto_stake_maturity: neuron_parameter.construct_auto_staking_maturity(),
                 vesting_period_seconds: None,
                 disburse_maturity_in_progress: vec![],
-                reward_events_to_neuron_reward_e8s: BTreeMap::new(),
+                reward_event_end_timestamp_seconds_to_neuron_reward_e8s: BTreeMap::new(),
             };
 
             // Add the neuron to the various data structures and indexes to support neurons. This
@@ -4938,18 +4938,26 @@ impl Governance {
                 } else {
                     neuron.maturity_e8s_equivalent += neuron_reward_e8s;
                 }
-                // Insert the neuron_reward_e8s into the reward_events_to_neuron_reward_e8s map on the neuron. 
-                neuron.reward_events_to_neuron_reward_e8s.insert( 
+                // Insert the neuron_reward_e8s into the reward_event_end_timestamp_seconds_to_neuron_reward_e8s map on the neuron. 
+                let map = &mut neuron.reward_event_end_timestamp_seconds_to_neuron_reward_e8s;
+                const MAX_KEYS: usize = MAX_KEEP_REWARD_EVENTS_TO_NEURON_REWARD_E8S_PER_NEURON as usize;
+                if map.len() > MAX_KEYS {
+                    log!(
+                        ERROR,
+                        "Invariant violated: reward_event_end_timestamp_seconds_to_neuron_reward_e8s.len() ({}) has more than ({}) \
+                        events for neuron {:?}. Only the maximum number of keys will be retained.",
+                        map.len(), MAX_KEYS, neuron.id,
+                    );
+                }
+                // Remove enough elements to satisfy the limit after adding the current event.
+                while map.len() + 1 > MAX_KEYS {
+                    // Prune the earliest reward event.
+                    map.pop_first();
+                }
+                map.insert( 
                     reward_event_end_timestamp_seconds, 
                     neuron_reward_e8s
                 );
-                // prune
-                while neuron.reward_events_to_neuron_reward_e8s.len() > MAX_KEEP_REWARD_EVENTS_TO_NEURON_REWARD_E8S_PER_NEURON as usize {
-                    // prune earliest.
-                    neuron.reward_events_to_neuron_reward_e8s.remove(
-                        &neuron.reward_events_to_neuron_reward_e8s.keys().min().unwrap().clone()
-                    );
-                }
                 distributed_e8s_equivalent += neuron_reward_e8s;
             }
         }

--- a/rs/sns/governance/src/neuron.rs
+++ b/rs/sns/governance/src/neuron.rs
@@ -24,6 +24,9 @@ pub const MAX_LIST_NEURONS_RESULTS: u32 = 100;
 /// The default voting_power_percentage_multiplier applied to a neuron.
 pub const DEFAULT_VOTING_POWER_PERCENTAGE_MULTIPLIER: u64 = 100;
 
+// The max number of reward_events_to_neuron_reward_e8s per neuron
+pub const MAX_KEEP_REWARD_EVENTS_TO_NEURON_REWARD_E8S_PER_NEURON: u64 = 5;
+
 /// The state of a neuron
 #[derive(Debug, PartialEq, Eq)]
 pub enum NeuronState {

--- a/rs/sns/governance/src/neuron.rs
+++ b/rs/sns/governance/src/neuron.rs
@@ -25,7 +25,7 @@ pub const MAX_LIST_NEURONS_RESULTS: u32 = 100;
 pub const DEFAULT_VOTING_POWER_PERCENTAGE_MULTIPLIER: u64 = 100;
 
 // The max number of reward_events_to_neuron_reward_e8s per neuron
-pub const MAX_KEEP_REWARD_EVENTS_TO_NEURON_REWARD_E8S_PER_NEURON: u64 = 5;
+pub const MAX_KEEP_REWARD_EVENTS_TO_NEURON_REWARD_E8S_PER_NEURON: u32 = 5;
 
 /// The state of a neuron
 #[derive(Debug, PartialEq, Eq)]

--- a/rs/sns/governance/src/neuron.rs
+++ b/rs/sns/governance/src/neuron.rs
@@ -24,7 +24,7 @@ pub const MAX_LIST_NEURONS_RESULTS: u32 = 100;
 /// The default voting_power_percentage_multiplier applied to a neuron.
 pub const DEFAULT_VOTING_POWER_PERCENTAGE_MULTIPLIER: u64 = 100;
 
-// The max number of reward_events_to_neuron_reward_e8s per neuron
+// The max number of reward events in the reward_event_end_timestamp_seconds_to_neuron_reward_e8s map per neuron.
 pub const MAX_KEEP_REWARD_EVENTS_TO_NEURON_REWARD_E8S_PER_NEURON: u32 = 5;
 
 /// The state of a neuron


### PR DESCRIPTION
This change lets SNSs share the revenue of the SNS that is generated through the dapp with the SNS neuron-holders proportional to the voting participation of the neuron holders. This is implemented by saving the neuron_reward_e8s of the latest 5 reward-events in each Neuron. This way, a SNS can call `list_neurons` and view the portion of a reward-event given to each neuron.    

The neuron_reward_e8s are saved on each neuron with the corresponding reward-event timestamp (reward_event_end_timestamp_seconds) so that when calling list_neurons over many chunks, the caller can correlate reward-events of the different neurons even if a reward-event is being added to the neurons in between the different list_neuron calls (the chunks of the list_neurons calls).
